### PR TITLE
Fix number of message sent

### DIFF
--- a/smtpc.go
+++ b/smtpc.go
@@ -485,8 +485,16 @@ func main() {
 	if !quiet {
 		go showProgress(nbmails_chan, nb_msgs)
 	}
+	// Compute quotient and remainder to make sure the exact number of messages is sent
+	quotient := nb_msgs / nb_threads
+	remainder := nb_msgs - (nb_threads * quotient)
 	for i := 0; i < nb_threads; i++ {
-		go sendMsg(a, nb_msgs/nb_threads, time_chan,
+		nb_send := quotient
+		if 0 < remainder {
+			nb_send += 1
+			remainder -= 1
+		}
+		go sendMsg(a, nb_send, time_chan,
 			nbmails_chan, single, tos,
 			froms, msgs, auth, body, dont_stop, ipsrcs, hello, quiet)
 	}

--- a/smtpc.go
+++ b/smtpc.go
@@ -342,7 +342,7 @@ func sendMsg(a *net.TCPAddr, nb_msgs int, time_chan chan int64, nbmails_chan cha
 		nbmails_chan <- count
 	}
 	end = time.Now()
-	time_chan <- int64(end.Sub(begin)) / 1000 / int64(nb_msgs)
+	time_chan <- end.Sub(begin).Nanoseconds()
 	return
 
 err_label:
@@ -491,11 +491,13 @@ func main() {
 			froms, msgs, auth, body, dont_stop, ipsrcs, hello, quiet)
 	}
 
+	// Wait for goroutines to complete and compute average per message processing time
 	var avg_time int64 = 0
 	for t := 0; t < nb_threads; t++ {
 		avg_time += <-time_chan
 	}
+	avg_time /= 1000 * int64(nb_msgs) // Divide by 1000 to convert from nanoseconds to microseconds
 
-	fmt.Printf("\nAverage processing time: %d\n", avg_time/int64(nb_threads))
+	fmt.Printf("\nAverage processing time: %d microseconds\n", avg_time)
 	return
 }


### PR DESCRIPTION
There are two changes here.

One is a fix that makes sure the number of messages sent is as requested by the user. A number of messages equal to the remainder of the division of the number of messages requested by the number of threads was previously left out.

The other change attempts to make the time accounting code more readable and to minimize rounding errors by making a single division rather than one in every thread.